### PR TITLE
Feat/105 클럽 가입 신청 리스트 조회 기능 

### DIFF
--- a/prisma/migrations/20241207092753_delete_status_in_club_request/migration.sql
+++ b/prisma/migrations/20241207092753_delete_status_in_club_request/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `status` on the `club_request` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "club_request" DROP COLUMN "status";
+
+-- DropEnum
+DROP TYPE "club_request_status";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -152,18 +152,10 @@ model ClubJoin {
   @@map("club_join")
 }
 
-enum ClubRequestStatus {
-  REQUESTED 
-  APPROVED
-  DELETED
-  @@map("club_request_status")
-}
-
 model ClubRequest {
   id        Int           @id @default(autoincrement())
   clubId    Int           @map("club_id")
   userId    Int           @map("user_id")
-  status    ClubRequestStatus @default(REQUESTED)
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 

--- a/src/club/club.controller.ts
+++ b/src/club/club.controller.ts
@@ -25,6 +25,7 @@ import { CreateClubPayload } from './payload/create-club.payload';
 import { ClubService } from './club.service';
 import { ClubDetailDto } from './dto/club-detail.dto';
 import { ClubQuery } from './query/club.query';
+import { ClubRequestListDto } from './dto/club.request.dto';
 
 @Controller('clubs')
 @ApiTags('Club API')
@@ -73,4 +74,28 @@ export class ClubController {
   ): Promise<void> {
     return this.clubService.requestClub(clubId, user);
   }
+
+  @Get(':clubId/request')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '클럽 가입 신청 목록 조회' })
+  @ApiOkResponse({ type: ClubRequestListDto })
+  async getClubRequests(
+    @Param('clubId', ParseIntPipe) clubId: number,
+    @CurrentUser() user: UserBaseInfo,
+  ): Promise<ClubRequestListDto> {
+    return this.clubService.getClubRequests(clubId, user);
+  }
+
+  // 고민1)
+  // dto를 따로 만들기
+  // vs
+  // 그냥 userId만 가져오기
+
+  // => dto안만들고 user정보만 가져올수 있나? 애초에 클럽장은 어디까지 볼 수 있지? 유저이름? 유저이메일? .. 흠..
+
+  // dto를 따로 만들고, 만약 클럽장 권한이 생각보다 작으면 dto 안의 요소를 줄이는 방법도 괜찮지 않을까?
+
+  // => 결론: dto를 사용합시다. 필요에 따라 정보노출을 조절하자.
+  // 호스트만 조회 가능한 로직!!!!
 }

--- a/src/club/club.repository.ts
+++ b/src/club/club.repository.ts
@@ -4,6 +4,7 @@ import { CreateClubData } from './type/create-club-data.type';
 import { ClubData } from './type/club-data.type';
 import { ClubDetailData } from './type/club-detail-data.type';
 import { ClubQuery } from './query/club.query';
+import { ClubRequestData } from './type/club-request-data.type';
 
 @Injectable()
 export class ClubRepository {
@@ -156,6 +157,24 @@ export class ClubRepository {
         name: true,
         description: true,
         maxPeople: true,
+      },
+    });
+  }
+
+  async getClubRequests(clubId: number): Promise<ClubRequestData[]> {
+    return this.prisma.clubRequest.findMany({
+      where: {
+        clubId,
+      },
+      select: {
+        id: true,
+        userId: true,
+        user: {
+          select: {
+            name: true,
+            email: true,
+          },
+        },
       },
     });
   }

--- a/src/club/club.service.ts
+++ b/src/club/club.service.ts
@@ -10,6 +10,7 @@ import { ClubDto, ClubListDto } from './dto/club.dto';
 import { ClubRepository } from './club.repository';
 import { ClubDetailDto } from './dto/club-detail.dto';
 import { ClubQuery } from './query/club.query';
+import { ClubRequestListDto } from './dto/club.request.dto';
 
 @Injectable()
 export class ClubService {
@@ -78,5 +79,22 @@ export class ClubService {
     }
 
     await this.clubRepository.requestClub(clubId, user.id);
+  }
+
+  async getClubRequests(
+    clubId: number,
+    user: UserBaseInfo,
+  ): Promise<ClubRequestListDto> {
+    const requests = await this.clubRepository.getClubRequests(clubId);
+
+    const club = await this.clubRepository.findClubById(clubId);
+    if (!club) {
+      throw new NotFoundException('클럽을 찾을 수 없습니다.');
+    }
+    if (club.hostId !== user.id) {
+      throw new ConflictException('클럽 주최자만 조회할 수 있습니다.');
+    }
+
+    return ClubRequestListDto.from(requests);
   }
 }

--- a/src/club/dto/club.request.dto.ts
+++ b/src/club/dto/club.request.dto.ts
@@ -1,0 +1,56 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ClubRequestData } from '../type/club-request-data.type';
+
+export class ClubRequestDto {
+  @ApiProperty({
+    description: '클럽 가입 신청 ID',
+    type: Number,
+  })
+  id!: number;
+
+  @ApiProperty({
+    description: '유저 ID',
+    type: Number,
+  })
+  userId!: number;
+
+  @ApiProperty({
+    description: '이름',
+    type: String,
+  })
+  name!: string;
+
+  @ApiProperty({
+    description: '이메일',
+    type: String,
+  })
+  email!: string;
+
+  // 일단 id, userId, name, email 제공했으나 클럽 주최자가 볼 수 있는 정보를 name, email로만 제한해야 하나 고민되긴한다..
+  static from(data: ClubRequestData): ClubRequestDto {
+    return {
+      id: data.id,
+      userId: data.userId,
+      name: data.user.name,
+      email: data.user.email,
+    };
+  }
+
+  static fromArray(data: ClubRequestData[]): ClubRequestDto[] {
+    return data.map((club) => ClubRequestDto.from(club));
+  }
+}
+
+export class ClubRequestListDto {
+  @ApiProperty({
+    description: '클럽 가입 신청 목록',
+    type: [ClubRequestDto],
+  })
+  clubRequests!: ClubRequestDto[];
+
+  static from(data: ClubRequestData[]): ClubRequestListDto {
+    return {
+      clubRequests: ClubRequestDto.fromArray(data),
+    };
+  }
+}

--- a/src/club/type/club-request-data.type.ts
+++ b/src/club/type/club-request-data.type.ts
@@ -1,0 +1,8 @@
+export type ClubRequestData = {
+  id: number;
+  userId: number;
+  user: {
+    name: string;
+    email: string;
+  };
+};


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CI/CD, INFRA
- [ ] Etc

## Purpose
- 어떤 목적의 작업인가요?
클럽장이 클럽 가입 신청 리스트 조회하는 기능 추가

## Why
- 어떤 이유로 작업하셨나요?(Optional)


## Additional context
- 추가로 알리고 싶으신 내용이 있으신가요?
클럽장이 현재 볼 수 있는 신청에 대한 정보는 유저id, 유저name, 유저email인데 혹시 더 제한해야 하나 고민됩니다. 일단 그대로여도 괜찮을까요? 

## Checklist
- Merge 나 Deploy 시 확인이 필요한 부분이 있다면 적어주세요.