### PR TITLE
Feat/113 리뷰 여러개 조회, 리뷰 한개 조회 기능 clubId, isArchived관련 수정

### DIFF
--- a/src/review/review.controller.ts
+++ b/src/review/review.controller.ts
@@ -48,12 +48,15 @@ export class ReviewController {
   }
 
   @Get(':reviewId')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOperation({ summary: '리뷰 상세 정보를 가져옵니다' })
   @ApiOkResponse({ type: ReviewDto })
   async getReviewById(
     @Param('reviewId', ParseIntPipe) reviewId: number,
+    @CurrentUser() user: UserBaseInfo,
   ): Promise<ReviewDto> {
-    return this.reviewService.getReviewById(reviewId);
+    return this.reviewService.getReviewById(reviewId, user);
   }
 
   @Get()

--- a/src/review/review.controller.ts
+++ b/src/review/review.controller.ts
@@ -57,10 +57,15 @@ export class ReviewController {
   }
 
   @Get()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOperation({ summary: '여러 리뷰 정보를 가져옵니다' })
   @ApiOkResponse({ type: ReviewListDto })
-  async getReviews(@Query() query: ReviewQuery): Promise<ReviewListDto> {
-    return this.reviewService.getReviews(query);
+  async getReviews(
+    @Query() query: ReviewQuery,
+    @CurrentUser() user: UserBaseInfo,
+  ): Promise<ReviewListDto> {
+    return this.reviewService.getReviews(query, user);
   }
 
   @Put(':reviewId')

--- a/src/review/review.repository.ts
+++ b/src/review/review.repository.ts
@@ -63,6 +63,16 @@ export class ReviewRepository {
     return !!review;
   }
 
+  async isUserJoinedClub(clubId: number, userId: number): Promise<boolean> {
+    const clubJoin = await this.prisma.clubJoin.findFirst({
+      where: {
+        clubId,
+        userId,
+        },
+    });
+    return !!clubJoin;
+  }
+  
   async isUserJoinedEvent(userId: number, eventId: number): Promise<boolean> {
     const event = await this.prisma.eventJoin.findUnique({
       where: {

--- a/src/review/review.repository.ts
+++ b/src/review/review.repository.ts
@@ -68,11 +68,11 @@ export class ReviewRepository {
       where: {
         clubId,
         userId,
-        },
+      },
     });
     return !!clubJoin;
   }
-  
+
   async isUserJoinedEvent(userId: number, eventId: number): Promise<boolean> {
     const event = await this.prisma.eventJoin.findUnique({
       where: {
@@ -137,7 +137,7 @@ export class ReviewRepository {
               },
             },
           ],
-        }
+        },
       },
       select: {
         id: true,

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -79,8 +79,8 @@ export class ReviewService {
     return ReviewDto.from(review);
   }
 
-  async getReviews(query: ReviewQuery): Promise<ReviewListDto> {
-    const reviews = await this.reviewRepository.getReviews(query);
+  async getReviews(query: ReviewQuery, user: UserBaseInfo): Promise<ReviewListDto> {
+    const reviews = await this.reviewRepository.getReviews(query, user.id);
 
     return ReviewListDto.from(reviews);
   }

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -70,35 +70,45 @@ export class ReviewService {
     return ReviewDto.from(review);
   }
 
-  async getReviewById(reviewId: number, user: UserBaseInfo): Promise<ReviewDto> {
+  async getReviewById(
+    reviewId: number,
+    user: UserBaseInfo,
+  ): Promise<ReviewDto> {
     const review = await this.reviewRepository.getReviewById(reviewId);
 
     if (!review) {
       throw new NotFoundException('Review가 존재하지 않습니다.');
     }
     const event = await this.reviewRepository.getEventById(review.eventId);
-    if (event!.clubId) { 
+    if (event!.clubId) {
       const isUserJoinedClub = await this.reviewRepository.isUserJoinedClub(
         event!.clubId,
         user.id,
       );
       if (!isUserJoinedClub) {
-        throw new ForbiddenException('클럽에 가입하지 않은 유저는 클럽 전용 모임의 리뷰를 볼 수 없습니다.');
+        throw new ForbiddenException(
+          '클럽에 가입하지 않은 유저는 클럽 전용 모임의 리뷰를 볼 수 없습니다.',
+        );
       }
     }
-    
+
     const isUserJoinedEvent = await this.reviewRepository.isUserJoinedEvent(
       user.id,
       review.eventId,
     );
     if (event!.isArchived && !isUserJoinedEvent) {
-      throw new ForbiddenException('아카이브된 모임의 리뷰는 참여자만 조회할 수 있습니다.');
+      throw new ForbiddenException(
+        '아카이브된 모임의 리뷰는 참여자만 조회할 수 있습니다.',
+      );
     }
 
     return ReviewDto.from(review);
   }
 
-  async getReviews(query: ReviewQuery, user: UserBaseInfo): Promise<ReviewListDto> {
+  async getReviews(
+    query: ReviewQuery,
+    user: UserBaseInfo,
+  ): Promise<ReviewListDto> {
     const reviews = await this.reviewRepository.getReviews(query, user.id);
 
     return ReviewListDto.from(reviews);


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CI/CD, INFRA
- [ ] Etc

## Purpose
- 어떤 목적의 작업인가요?
리뷰 여러개 조회, 리뷰 한개 조회 기능에 clubId와 isArchived관련 제한을 추가했습니다. 


## Why
- 어떤 이유로 작업하셨나요?(Optional)


## Additional context
- 추가로 알리고 싶으신 내용이 있으신가요?
리뷰 생성, 수정, 삭제의 경우 모임 참여자인지 확인하는 시점에서 이미 검증이 끝나서 따로 clubId나 isArchived에 대한 처리가 필요 없다고 생각하고 일단 그대로 뒀습니다. 제가 이해한 것이 맞을까요? 

## Checklist
- Merge 나 Deploy 시 확인이 필요한 부분이 있다면 적어주세요.